### PR TITLE
testkit library example

### DIFF
--- a/module1/pom.xml
+++ b/module1/pom.xml
@@ -13,5 +13,23 @@
 
     <artifactId>module1</artifactId>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <id>Jar Tests Package</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/module1/src/test/java/org/example/AbstractGreetingTest.java
+++ b/module1/src/test/java/org/example/AbstractGreetingTest.java
@@ -1,0 +1,14 @@
+package org.example;
+
+import static org.junit.Assert.assertTrue;
+
+public abstract class AbstractGreetingTest {
+
+    abstract IGreeting getGreetingImpl();
+
+    public void test() {
+        assertTrue(getGreetingImpl().getGreeting().contains("Hello world"));
+    }
+
+
+}

--- a/module1/src/test/java/org/example/LibraryTest.java
+++ b/module1/src/test/java/org/example/LibraryTest.java
@@ -1,17 +1,10 @@
 package org.example;
 
-import org.junit.Test;
+public class LibraryTest extends AbstractGreetingTest{
 
-import static org.junit.Assert.*;
-
-public class LibraryTest {
-
-    @Test
-    public void test() throws InterruptedException {
-        Library library = new Library();
-        // we block the thread for 10 seconds to simulate a long-running operation
-        Thread.sleep(60_000);
-        assertEquals("Hello world!", library.getGreeting());
+    @Override
+    IGreeting getGreetingImpl() {
+        return new Library();
     }
 
 }

--- a/module2/pom.xml
+++ b/module2/pom.xml
@@ -19,6 +19,12 @@
             <groupId>org.example</groupId>
             <artifactId>module1</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.example</groupId>
+            <artifactId>module1</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
     </dependencies>
 
 </project>

--- a/module2/src/test/java/org/example/ApplicationTest.java
+++ b/module2/src/test/java/org/example/ApplicationTest.java
@@ -1,14 +1,9 @@
 package org.example;
 
-import org.junit.Test;
+public class ApplicationTest extends AbstractGreetingTest {
 
-import static org.junit.Assert.*;
-
-public class ApplicationTest {
-
-    @Test
-    public void test() {
-        assertEquals("\"Hello world!\" from Application!", Application.SINGLETON.getGreeting());
+    @Override
+    IGreeting getGreetingImpl() {
+        return Application.SINGLETON;
     }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,13 @@
             </dependency>
             <dependency>
                 <groupId>org.example</groupId>
+                <artifactId>module1</artifactId>
+                <version>${revision}</version>
+                <scope>test</scope>
+                <type>test-jar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.example</groupId>
                 <artifactId>module2</artifactId>
                 <version>${revision}</version>
             </dependency>


### PR DESCRIPTION
场景：抽象单测类

大多数人对面向接口编程，只停留在写一个 interface 再写一个 Impl 的实现中，对于 interface 没有意识到除了抽象方法外，还需要提供什么。

在 module1 中 `IGreeting` 定义了其实现必须有 `String getGreeting()` 实现，对于问候语应该包含什么却没有约束和规范，很大程度是因为开发者、设计接口人的短见，只懂理论不懂实践。

本案例给出了一个 `AbstractGreetingTest` 抽象测试类，该类的目的是约束其所有实现类，都必须满足问候语中包含 `Hello world` 短语，在 maven 中，如果要实现对某个模块的测试依赖，官方是不支持的，只能基于一个插件去实现，实现方式我认为很丑陋（相比于其他构建工具）